### PR TITLE
Make it installable with pip.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Human added.
+.local/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,132 @@
-env/
-.local/
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.egg-info
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+coverage.json
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+rest_env/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+

--- a/README.md
+++ b/README.md
@@ -22,12 +22,8 @@ method. Using `setPostPackageLengthLimit(256)` should work in most cases. If
 the client PC has a requirement for lower MTU, then this must be set lower. Or
 if/when `bleak` can correctly obtain MTU for a given platform, it can be removed.
 
-## Requirements
+## Install
 
-```sh
-# bleak - develop branch
-pip install https://github.com/hbldh/bleak/archive/refs/heads/develop.zip
-# cryptography
-pip install cryptography==38.0.4
-# (later versions don't allow reading certain keys, didn't dig very deep)
+```
+pip install git+https://github.com/someburner/pyBlufi.git
 ```

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,10 @@ from setuptools import setup, find_packages
 setup(
     name='pyBlufi',
     version='0.0.1',
-    packages=find_packages('blufi'),
+    description="Python utility to interface with esp32 Blufi component.",
+    packages=find_packages(),
+    install_requires=[
+        'cryptography==38.0.4',
+        'bleak==0.21.1'
+    ],
 )


### PR DESCRIPTION
I took the liberty to change the setup.py so it is now possible to install with pip without manual interventions.
So it can now be installed like so:
```console
pip install git+https://github.com/someburner/pyBlufi.git
```
Also change the README to now also letting users know.